### PR TITLE
Remove `Node::GetEndpoint()`

### DIFF
--- a/mage/core/core.cc
+++ b/mage/core/core.cc
@@ -239,13 +239,6 @@ void Core::RegisterLocalHandleAndEndpoint(
     handle_table_lock_.unlock();
   }
 
-  // Next, we check that `local_endpoint` doesn't already exist in this node.
-  {
-    std::shared_ptr<Endpoint> null_endpoint =
-        node_->GetEndpoint(local_endpoint->name);
-    CHECK(!null_endpoint);
-  }
-
   // Finally, we can register the endpoint with `this` and `node_`.
   LOG("Core::RegisterLocalHandle registering local_handle (%d) and endpoint "
       "with name: %s",

--- a/mage/core/node.cc
+++ b/mage/core/node.cc
@@ -34,14 +34,6 @@ Node::InitializeAndEntangleEndpoints() const {
   return std::make_pair(ep1, ep2);
 }
 
-std::shared_ptr<Endpoint> Node::GetEndpoint(std::string endpoint_name) {
-  auto it = local_endpoints_.find(endpoint_name);
-  if (it == local_endpoints_.end())
-    return nullptr;
-
-  return it->second;
-}
-
 void Node::RegisterEndpoint(std::shared_ptr<Endpoint> new_endpoint) {
   // Make sure the endpoint isn't already registered.
   auto it = local_endpoints_.find(new_endpoint->name);

--- a/mage/core/node.h
+++ b/mage/core/node.h
@@ -32,7 +32,6 @@ class Node : public Channel::Delegate {
   void AcceptInvitation(int fd);
   void SendMessage(std::shared_ptr<Endpoint> local_endpoint, Message message);
 
-  std::shared_ptr<Endpoint> GetEndpoint(std::string);
   void RegisterEndpoint(std::shared_ptr<Endpoint>);
 
   // Channel::Delegate implementation:


### PR DESCRIPTION
This method was only used by `Core::RegisterLocalHandleAndEndpoint()` to ensure that no endpoint with the newly-generated name (for the newly-created but not-yet-registered `Endpoint`) already exists. This is not necessary however, because `Node::RegisterEndpoint()` already manually checks this.