### PR TITLE
Remove `Channel::remote_node_name_`

### DIFF
--- a/mage/core/channel.cc
+++ b/mage/core/channel.cc
@@ -74,12 +74,8 @@ void Channel::Start() {
   io_task_loop_.WatchSocket(this);
 }
 
-void Channel::SetRemoteNodeName(const std::string& name) {
-  CHECK_ON_THREAD(base::ThreadType::UI);
-  remote_node_name_ = name;
-}
-
 void Channel::SendInvitation(std::string inviter_name,
+                             std::string temporary_remote_node_name,
                              std::string intended_endpoint_peer_name) {
   CHECK_ON_THREAD(base::ThreadType::UI);
   Message message(MessageType::SEND_INVITATION);
@@ -91,8 +87,8 @@ void Channel::SendInvitation(std::string inviter_name,
          inviter_name.size());
 
   // Serialize temporary remote node name.
-  memcpy(params.data()->temporary_remote_node_name, remote_node_name_.c_str(),
-         remote_node_name_.size());
+  memcpy(params.data()->temporary_remote_node_name,
+         temporary_remote_node_name.c_str(), temporary_remote_node_name.size());
 
   // Serialize intended endpoint peer name.
   memcpy(params.data()->intended_endpoint_peer_name,

--- a/mage/core/channel.h
+++ b/mage/core/channel.h
@@ -25,6 +25,7 @@ class Channel : public base::TaskLoopForIO::SocketReader {
   void Start();
   void SetRemoteNodeName(const std::string& name);
   void SendInvitation(std::string inviter_name,
+                      std::string temporary_remote_node_name,
                       std::string intended_endpoint_peer_name);
   void SendAcceptInvitation(std::string temporary_remote_node_name,
                             std::string actual_node_name,
@@ -35,10 +36,6 @@ class Channel : public base::TaskLoopForIO::SocketReader {
   void OnCanReadFromSocket() override;
 
  private:
-  // This is always initialized as something temporary until we hear back from
-  // the remote node and it tells us its name.
-  std::string remote_node_name_;
-
   // The |Delegate| owns |this|, so this pointer will never be null.
   Delegate* delegate_;
 

--- a/mage/core/node.cc
+++ b/mage/core/node.cc
@@ -123,8 +123,8 @@ MessagePipe Node::SendInvitationAndGetMessagePipe(int fd) {
   // expensive, and we can avoid it with one-time proper ordering.
   std::unique_ptr<Channel>& channel = it.first->second;
   channel->Start();
-  channel->SetRemoteNodeName(temporary_remote_node_name);
   channel->SendInvitation(/*inviter_name=*/name_,
+                          /*temporary_remote_node_name=*/temporary_remote_node_name,
                           /*intended_endpoint_peer_name=*/
                           remote_endpoint->peer_address.endpoint_name);
 


### PR DESCRIPTION
In preparation for #13, this PR removes a little bit of state on `Channel` that is confusing and not really necessary. This member should really be named something like "temporary invitee remote node name", since this is only ever set for channels created as part of the send-invitation flow, and actually it is never even updated. It's really not that useful, so this PR simply removes it.