### PR TITLE
More of Mage core is thread-safe

### DIFF
--- a/mage/BUILD
+++ b/mage/BUILD
@@ -13,6 +13,7 @@ filegroup(
     "//mage/test:child_sends_send_invitation_pipe_to_parent",
     "//mage/test:child_sends_two_pipes_to_parent",
     "//mage/test:pass_pipe_back_and_forth",
+    "//mage/test:child_threads_send_racy_ipcs",
   ],
 )
 

--- a/mage/core/channel.cc
+++ b/mage/core/channel.cc
@@ -17,8 +17,6 @@ namespace {
 
 // Helper function to print the full human-readable contents of a mage::Message.
 void PrintFullMessageContents(Message& message) {
-  // CHECK_ON_THREAD(base::ThreadType::UI);
-
   std::vector<char>& payload_buffer = message.payload_buffer();
 
   MessageHeader* header =
@@ -61,23 +59,19 @@ Channel::Channel(int fd, Delegate* delegate)
     : SocketReader(fd),
       delegate_(delegate),
       io_task_loop_(*base::GetIOThreadTaskLoop()) {
-  CHECK_ON_THREAD(base::ThreadType::UI);
 }
 
 Channel::~Channel() {
-  CHECK_ON_THREAD(base::ThreadType::UI);
   io_task_loop_.UnwatchSocket(this);
 }
 
 void Channel::Start() {
-  CHECK_ON_THREAD(base::ThreadType::UI);
   io_task_loop_.WatchSocket(this);
 }
 
 void Channel::SendInvitation(std::string inviter_name,
                              std::string temporary_remote_node_name,
                              std::string intended_endpoint_peer_name) {
-  CHECK_ON_THREAD(base::ThreadType::UI);
   Message message(MessageType::SEND_INVITATION);
   MessageFragment<SendInvitationParams> params(message);
   params.Allocate();
@@ -103,7 +97,6 @@ void Channel::SendAcceptInvitation(
     std::string temporary_remote_node_name,
     std::string actual_node_name,
     std::string accept_invitation_endpoint_name) {
-  // CHECK(IsOnIOThread());
   Message message(MessageType::ACCEPT_INVITATION);
   MessageFragment<SendAcceptInvitationParams> params(message);
   params.Allocate();
@@ -127,11 +120,11 @@ void Channel::SendAcceptInvitation(
 
 void Channel::SendMessage(Message message) {
   LOG("\n\nChannel::SendMessage(): getpid(): %d, fd_: %d", getpid(), fd_);
-  // CHECK_ON_THREAD(base::ThreadType::UI);
   PrintFullMessageContents(message);
 
   std::vector<char>& payload_buffer = message.payload_buffer();
   CHECK_EQ(message.Size(), (int)payload_buffer.size());
+  // TODO(domfarolino): Lock this section so that we don't interleave writes.
   int rv = write(fd_, payload_buffer.data(), payload_buffer.size());
   CHECK_EQ(rv, message.Size());
 }

--- a/mage/core/channel.cc
+++ b/mage/core/channel.cc
@@ -124,7 +124,7 @@ void Channel::SendMessage(Message message) {
 
   std::vector<char>& payload_buffer = message.payload_buffer();
   CHECK_EQ(message.Size(), (int)payload_buffer.size());
-  // TODO(domfarolino): Lock this section so that we don't interleave writes.
+  // This is thread-safe, per https://stackoverflow.com/a/42442886.
   int rv = write(fd_, payload_buffer.data(), payload_buffer.size());
   CHECK_EQ(rv, message.Size());
 }

--- a/mage/core/core.cc
+++ b/mage/core/core.cc
@@ -207,6 +207,7 @@ MessagePipe Core::RecoverNewMessagePipeFromEndpointDescriptor(
 }
 
 MessagePipe Core::GetNextMessagePipe() {
+  // TODO(domfarolino): Probably lock `next_available_handle_` here.
   return next_available_handle_++;
 }
 

--- a/mage/core/core.cc
+++ b/mage/core/core.cc
@@ -39,10 +39,12 @@ Core* Core::Get() {
 // static
 std::vector<MessagePipe> Core::CreateMessagePipes() {
   std::vector<MessagePipe> return_handles = Get()->node_->CreateMessagePipes();
+  Get()->handle_table_lock_.lock();
   CHECK_NE(Get()->handle_table_.find(return_handles[0]),
            Get()->handle_table_.end());
   CHECK_NE(Get()->handle_table_.find(return_handles[1]),
            Get()->handle_table_.end());
+  Get()->handle_table_lock_.unlock();
   return return_handles;
 }
 
@@ -207,8 +209,10 @@ MessagePipe Core::RecoverNewMessagePipeFromEndpointDescriptor(
 }
 
 MessagePipe Core::GetNextMessagePipe() {
-  // TODO(domfarolino): Probably lock `next_available_handle_` here.
-  return next_available_handle_++;
+  next_available_handle_lock_.lock();
+  int return_handle = next_available_handle_++;
+  next_available_handle_lock_.unlock();
+  return return_handle;
 }
 
 void Core::OnReceivedAcceptInvitation() {

--- a/mage/core/core.h
+++ b/mage/core/core.h
@@ -31,6 +31,7 @@ class Core {
   static void ShutdownCleanly();
 
   static Core* Get();
+  // Thread-safe.
   static std::vector<MessagePipe> CreateMessagePipes();
   static MessagePipe SendInvitationAndGetMessagePipe(
       int fd,
@@ -64,9 +65,12 @@ class Core {
   static MessagePipe RecoverNewMessagePipeFromEndpointDescriptor(
       const EndpointDescriptor& endpoint_descriptor);
 
+  // Thread-safe.
   MessagePipe GetNextMessagePipe();
+
   void OnReceivedAcceptInvitation();
   void OnReceivedInvitation(std::shared_ptr<Endpoint> local_endpoint);
+  // Thread-safe.
   void RegisterLocalHandleAndEndpoint(MessagePipe local_handle,
                                       std::shared_ptr<Endpoint> local_endpoint);
 

--- a/mage/core/core.h
+++ b/mage/core/core.h
@@ -96,6 +96,7 @@ class Core {
   base::Mutex handle_table_lock_;
 
   MessagePipe next_available_handle_ = 1;
+  base::Mutex next_available_handle_lock_;
 
   // This is optionally supplied when sending an invitation. It reports back
   // when the remote process has accepted the invitation. Guaranteed to be

--- a/mage/core/core_unittest.cc
+++ b/mage/core/core_unittest.cc
@@ -51,20 +51,46 @@ class DummyProcessLauncher {
 
 namespace mage {
 
-class CoreUnitTest : public testing::Test {
+enum class MainThreadType {
+  kUIThread,
+  kIOThread,
+};
+
+class CoreUnitTest : public testing::TestWithParam<MainThreadType> {
  public:
   CoreUnitTest(): io_thread(base::ThreadType::IO) {}
 
+  // Provides meaningful param names instead of /0 and /1 etc.
+  static std::string DescribeParams(
+      const ::testing::TestParamInfo<ParamType>& info) {
+    switch (info.param) {
+      case MainThreadType::kUIThread:
+        return "MainThreadUI";
+      case MainThreadType::kIOThread:
+        return "MainThreadIO";
+      default:
+        NOTREACHED();
+    }
+
+    NOTREACHED();
+    return "NOTREACHED";
+  }
+
   void SetUp() override {
     dummy_launcher = std::unique_ptr<DummyProcessLauncher>(new DummyProcessLauncher());
-    main_thread = base::TaskLoop::Create(base::ThreadType::UI);
-    io_thread.Start();
-    // Mage relies on `base::GetIOThreadTaskLoop()` being synchronously
-    // available from the UI thread upon start up, which only happens after the
-    // IO thread has actually started, which we can know by only continuing once
-    // we've confirmed it is running tasks.
-    io_thread.GetTaskRunner()->PostTask(main_thread->QuitClosure());
-    main_thread->Run();
+    if (GetParam() == MainThreadType::kUIThread) {
+      main_thread = base::TaskLoop::Create(base::ThreadType::UI);
+      io_thread.Start();
+      // Mage relies on `base::GetIOThreadTaskLoop()` being synchronously
+      // available from the UI thread upon start up, which only happens after the
+      // IO thread has actually started, which we can know by only continuing once
+      // we've confirmed it is running tasks.
+      io_thread.GetTaskRunner()->PostTask(main_thread->QuitClosure());
+      main_thread->Run();
+    } else {
+      CHECK_EQ(GetParam(), MainThreadType::kIOThread);
+      main_thread = base::TaskLoop::Create(base::ThreadType::IO);
+    }
 
     mage::Core::Init();
     EXPECT_TRUE(mage::Core::Get());
@@ -95,18 +121,23 @@ class CoreUnitTest : public testing::Test {
   base::Thread io_thread;
 };
 
-TEST_F(CoreUnitTest, CoreInitStateUnitTest) {
+INSTANTIATE_TEST_SUITE_P(All,
+                         CoreUnitTest,
+                         testing::Values(MainThreadType::kUIThread, MainThreadType::kIOThread),
+                         &CoreUnitTest::DescribeParams);
+
+TEST_P(CoreUnitTest, CoreInitStateUnitTest) {
   EXPECT_EQ(CoreHandleTable().size(), 0);
   EXPECT_EQ(NodeLocalEndpoints().size(), 0);
 }
 
-TEST_F(CoreUnitTest, UseUnboundRemoteCrashes) {
+TEST_P(CoreUnitTest, UseUnboundRemoteCrashes) {
   mage::Remote<magen::TestInterface> remote;
   ASSERT_DEATH({
     remote->SendMoney(0, "");
   }, "bound_*");
 }
-TEST_F(CoreUnitTest, UseUnboundRemoteCrashes2) {
+TEST_P(CoreUnitTest, UseUnboundRemoteCrashes2) {
   std::vector<mage::MessagePipe> pipes = mage::Core::CreateMessagePipes();
   mage::Remote<magen::TestInterface> remote;
   remote.Bind(pipes[0]);
@@ -124,7 +155,7 @@ TEST_F(CoreUnitTest, UseUnboundRemoteCrashes2) {
 // endpoints bound to a remote, as this test sadly asserts. This isn't great
 // behavior, but it shouldn't really be possible to run into anyways once
 // MessagePipes move-only.
-TEST_F(CoreUnitTest, SendBoundRemoteTechnicallyAllowedUnitTest) {
+TEST_P(CoreUnitTest, SendBoundRemoteTechnicallyAllowedUnitTest) {
   std::vector<mage::MessagePipe> first_pair = mage::Core::CreateMessagePipes();
   std::vector<mage::MessagePipe> second_pair = mage::Core::CreateMessagePipes();
 
@@ -142,7 +173,7 @@ class SIDummy : public magen::SecondInterface {
   void NotifyDoneViaCallback() { NOTREACHED(); }
   void SendReceiverForThirdInterface(MessagePipe receiver) { NOTREACHED(); }
 };
-TEST_F(CoreUnitTest, SendBoundReceiverUnitTest) {
+TEST_P(CoreUnitTest, SendBoundReceiverUnitTest) {
   std::vector<mage::MessagePipe> first_pair = mage::Core::CreateMessagePipes();
   std::vector<mage::MessagePipe> second_pair = mage::Core::CreateMessagePipes();
 
@@ -164,21 +195,32 @@ class SecondInterfaceOnlyStringAcceptor : public magen::SecondInterface {
   void NotifyDoneViaCallback() { NOTREACHED(); }
   void SendReceiverForThirdInterface(MessagePipe receiver) { NOTREACHED(); }
 };
-TEST_F(CoreUnitTest, RemoteAndReceiverDifferentInterfaces) {
-  std::vector<mage::MessagePipe> pipes = mage::Core::CreateMessagePipes();
-
-  mage::Remote<magen::FirstInterface> remote(pipes[0]);
-  mage::Receiver<magen::SecondInterface> receiver;
-  SecondInterfaceOnlyStringAcceptor second_interface_impl;
-  receiver.Bind(pipes[1], &second_interface_impl);
-
-  remote->SendString("Dominic");
+TEST_P(CoreUnitTest, RemoteAndReceiverDifferentInterfaces) {
   ASSERT_DEATH({
+    // `ASSERT_DEATH` forks the process, but does so in a way that doesn't
+    // initialize `main_thread` correctly if it is an "IO" thread. That's
+    // because the underlying thread's pipe (file descriptor, mach port, etc.)
+    // doesn't necessarily get opened properly (on macOS at the very least). So
+    // actually *running* the loop (if it doesn't get initialized properly
+    // *inside* the new process) will fail.
+    if (GetParam() == MainThreadType::kIOThread) {
+      main_thread.reset();
+      main_thread = base::TaskLoop::Create(base::ThreadType::IO);
+    }
+
+    std::vector<mage::MessagePipe> pipes = mage::Core::CreateMessagePipes();
+
+    mage::Remote<magen::FirstInterface> remote(pipes[0]);
+    mage::Receiver<magen::SecondInterface> receiver;
+    SecondInterfaceOnlyStringAcceptor second_interface_impl;
+    receiver.Bind(pipes[1], &second_interface_impl);
+
+    remote->SendString("Dominic");
     main_thread->Run();
   }, "false*");
 }
 
-TEST_F(CoreUnitTest, InitializeAndEntangleEndpointsUnitTest) {
+TEST_P(CoreUnitTest, InitializeAndEntangleEndpointsUnitTest) {
   const auto& [local, remote] = Node().InitializeAndEntangleEndpoints();
 
   EXPECT_EQ(CoreHandleTable().size(), 0);
@@ -196,7 +238,7 @@ TEST_F(CoreUnitTest, InitializeAndEntangleEndpointsUnitTest) {
   EXPECT_EQ(remote->peer_address.endpoint_name, local->name);
 }
 
-TEST_F(CoreUnitTest, SendInvitationUnitTest) {
+TEST_P(CoreUnitTest, SendInvitationUnitTest) {
   MessagePipe message_pipe =
     mage::Core::SendInvitationAndGetMessagePipe(
       dummy_launcher->GetLocalFd()
@@ -212,7 +254,7 @@ TEST_F(CoreUnitTest, SendInvitationUnitTest) {
   remote->Method1(1, .4, "test");
 }
 
-TEST_F(CoreUnitTest, AcceptInvitationUnitTest) {
+TEST_P(CoreUnitTest, AcceptInvitationUnitTest) {
   mage::Core::AcceptInvitation(dummy_launcher->GetLocalFd(),
                                [](MessagePipe) {
                                  NOTREACHED();

--- a/mage/core/mage_test.cc
+++ b/mage/core/mage_test.cc
@@ -186,20 +186,47 @@ class ProcessLauncher {
 
 }; // namespace
 
-class MageTest : public testing::Test {
+enum class MainThreadType {
+  kUIThread,
+  kIOThread,
+};
+
+class MageTest : public testing::TestWithParam<MainThreadType> {
  public:
   MageTest(): io_thread(base::ThreadType::IO) {}
 
+  // Provides meaningful param names instead of /0 and /1 etc.
+  static std::string DescribeParams(
+      const ::testing::TestParamInfo<ParamType>& info) {
+    switch (info.param) {
+      case MainThreadType::kUIThread:
+        return "MainThreadUI";
+      case MainThreadType::kIOThread:
+        return "MainThreadIO";
+      default:
+        NOTREACHED();
+    }
+
+    NOTREACHED();
+    return "NOTREACHED";
+  }
+
   void SetUp() override {
     launcher = std::unique_ptr<ProcessLauncher>(new ProcessLauncher());
-    main_thread = base::TaskLoop::Create(base::ThreadType::UI);
-    io_thread.Start();
-    // Mage relies on `base::GetIOThreadTaskLoop()` being synchronously
-    // available from the UI thread upon start up, which only happens after the
-    // IO thread has actually started, which we can know by only continuing once
-    // we've confirmed it is running tasks.
-    io_thread.GetTaskRunner()->PostTask(main_thread->QuitClosure());
-    main_thread->Run();
+
+    if (GetParam() == MainThreadType::kUIThread) {
+      main_thread = base::TaskLoop::Create(base::ThreadType::UI);
+      io_thread.Start();
+      // Mage relies on `base::GetIOThreadTaskLoop()` being synchronously
+      // available from the UI thread upon start up, which only happens after the
+      // IO thread has actually started, which we can know by only continuing once
+      // we've confirmed it is running tasks.
+      io_thread.GetTaskRunner()->PostTask(main_thread->QuitClosure());
+      main_thread->Run();
+    } else {
+      CHECK_EQ(GetParam(), MainThreadType::kIOThread);
+      main_thread = base::TaskLoop::Create(base::ThreadType::IO);
+    }
 
     mage::Core::Init();
     EXPECT_TRUE(mage::Core::Get());
@@ -210,6 +237,14 @@ class MageTest : public testing::Test {
     io_thread.StopWhenIdle(); // Blocks.
     main_thread.reset();
     launcher.reset();
+  }
+
+  void CheckThread() {
+    if (GetParam() == MainThreadType::kUIThread) {
+      CHECK_ON_THREAD(base::ThreadType::UI);
+    } else {
+      CHECK_ON_THREAD(base::ThreadType::IO);
+    }
   }
 
  protected:
@@ -230,8 +265,13 @@ class MageTest : public testing::Test {
   base::Thread io_thread;
 };
 
+INSTANTIATE_TEST_SUITE_P(All,
+                         MageTest,
+                         testing::Values(MainThreadType::kUIThread, MainThreadType::kIOThread),
+                         &MageTest::DescribeParams);
+
 // In this test, the parent process is the inviter and a mage::Receiver.
-TEST_F(MageTest, ParentIsInviterAndReceiver) {
+TEST_P(MageTest, ParentIsInviterAndReceiver) {
   launcher->Launch(kChildAcceptorAndRemote);
 
   MessagePipe message_pipe =
@@ -253,7 +293,7 @@ TEST_F(MageTest, ParentIsInviterAndReceiver) {
 }
 
 // In this test, the parent process is the invitee and a mage::Receiver.
-TEST_F(MageTest, ParentIsAcceptorAndReceiver) {
+TEST_P(MageTest, ParentIsAcceptorAndReceiver) {
   launcher->Launch(kChildInviterAndRemote);
 
   mage::Core::AcceptInvitation(launcher->GetLocalFd(),
@@ -262,7 +302,7 @@ TEST_F(MageTest, ParentIsAcceptorAndReceiver) {
     EXPECT_EQ(CoreHandleTable().size(), 1);
     EXPECT_EQ(NodeLocalEndpoints().size(), 1);
 
-    CHECK_ON_THREAD(base::ThreadType::UI);
+    CheckThread();
     TestInterfaceImpl impl(message_pipe);
 
     // Let the message come in from the remote inviter.
@@ -297,7 +337,7 @@ TEST_F(MageTest, ParentIsAcceptorAndReceiver) {
 // depending on whether or not the mage::Remote is used before or after it
 // learns that we accepted the invitation. This should be completely opaque to
 // the user, which is why we have to test it.
-TEST_F(MageTest, ParentIsAcceptorAndReceiverButChildBlocksOnAcceptance) {
+TEST_P(MageTest, ParentIsAcceptorAndReceiverButChildBlocksOnAcceptance) {
   launcher->Launch(kInviterAsRemoteBlockOnAcceptance);
 
   mage::Core::AcceptInvitation(launcher->GetLocalFd(),
@@ -306,7 +346,7 @@ TEST_F(MageTest, ParentIsAcceptorAndReceiverButChildBlocksOnAcceptance) {
     EXPECT_EQ(CoreHandleTable().size(), 1);
     EXPECT_EQ(NodeLocalEndpoints().size(), 1);
 
-    CHECK_ON_THREAD(base::ThreadType::UI);
+    CheckThread();
     TestInterfaceImpl impl(message_pipe);
 
     // Let the message come in from the remote inviter.
@@ -372,7 +412,7 @@ TEST_F(MageTest, ParentIsAcceptorAndReceiverButChildBlocksOnAcceptance) {
 //   3.) Send invitation (pipe used for FirstInterface)
 //   4.) Send one of SecondInterface's handles to other process via
 //       FirstInterface and assert everything was received
-TEST_F(MageTest, SendHandleAndQueuedMessageOverInitialPipe_01) {
+TEST_P(MageTest, SendHandleAndQueuedMessageOverInitialPipe_01) {
   launcher->Launch(kChildReceiveHandle);
 
   // 1.) Send invitation (pipe used for FirstInterface)
@@ -424,7 +464,7 @@ TEST_F(MageTest, SendHandleAndQueuedMessageOverInitialPipe_01) {
   second_remote->NotifyDoneViaCallback();
   main_thread->Run();
 }
-TEST_F(MageTest, SendHandleAndQueuedMessageOverInitialPipe_02) {
+TEST_P(MageTest, SendHandleAndQueuedMessageOverInitialPipe_02) {
   launcher->Launch(kChildReceiveHandle);
 
   // 1.) Send invitation (pipe used for FirstInterface)
@@ -473,7 +513,7 @@ TEST_F(MageTest, SendHandleAndQueuedMessageOverInitialPipe_02) {
   second_remote->NotifyDoneViaCallback();
   main_thread->Run();
 }
-TEST_F(MageTest, SendHandleAndQueuedMessageOverInitialPipe_05) {
+TEST_P(MageTest, SendHandleAndQueuedMessageOverInitialPipe_05) {
   launcher->Launch(kChildReceiveHandle);
 
   // 1.) Create message pipes for SecondInterface and callback
@@ -532,7 +572,7 @@ TEST_F(MageTest, SendHandleAndQueuedMessageOverInitialPipe_05) {
 // queueing differently depending on whether messages were queued on the
 // invitation pipe or a generic pipe made arbitrarily later. This test shows
 // that the two paths have been unified.
-TEST_F(MageTest, SendHandleAndQueuedMessageOverArbitraryPipe) {
+TEST_P(MageTest, SendHandleAndQueuedMessageOverArbitraryPipe) {
   launcher->Launch(kChildReceiveHandle);
 
   // 1.) Send invitation (pipe used for FirstInterface)
@@ -639,7 +679,7 @@ class SecondInterfaceImplDummy1 final : public magen::SecondInterface {
 // endpoints with local peers (that might be proxying). This test asserts that
 // we do the same thing but when sending an endpoint-bearing message to a local
 // endpoint whose peer is remote.
-TEST_F(MageTest, SendInvitationAndReceiveQueuedEndpointsFromAcceptor) {
+TEST_P(MageTest, SendInvitationAndReceiveQueuedEndpointsFromAcceptor) {
   launcher->Launch(kChildSendMessageWithQueuedHandle);
 
   // 1.) Send invitation (pipe used for FirstInterface)
@@ -679,7 +719,7 @@ class FirstInterfaceImplDummy final : public magen::FirstInterface {
 };
 // This test shows that when a node receives a message with a single handle, we
 // register one backing endpoint with `Core`.
-TEST_F(MageTest, ReceiveHandleFromRemoteNode) {
+TEST_P(MageTest, ReceiveHandleFromRemoteNode) {
   launcher->Launch(kParentReceiveHandle);
 
   MessagePipe invitation_pipe =
@@ -741,7 +781,7 @@ class ChildPassInvitationPipeBackToParentMessagePiper :
 // message pipe it gets from accepting an invitation from its parent, and sends
 // it back to the parent (over a separate message pipe). Parent now has a
 // remote/receiver and should be fully functional.
-TEST_F(MageTest, ChildPassAcceptInvitationPipeBackToParent) {
+TEST_P(MageTest, ChildPassAcceptInvitationPipeBackToParent) {
   launcher->Launch(kChildSendsAcceptInvitationPipeToParent);
 
   MessagePipe invitation_pipe =
@@ -770,7 +810,7 @@ TEST_F(MageTest, ChildPassAcceptInvitationPipeBackToParent) {
 // message pipe it gets from sending an invitation to its parent, and sends
 // it back to the parent (over a separate message pipe). Parent now has a
 // remote/receiver and should be fully functional.
-TEST_F(MageTest, ChildPassSendInvitationPipeBackToParent) {
+TEST_P(MageTest, ChildPassSendInvitationPipeBackToParent) {
   launcher->Launch(kChildSendsSendInvitationPipeToParent);
 
   mage::Core::AcceptInvitation(launcher->GetLocalFd(),
@@ -857,7 +897,7 @@ class ChildPassTwoPipesToParent : public magen::FirstInterface,
 // in the child process should be marked as proxying to each other. When the
 // parent receives both pipes, it binds them to a remote/receiver pair and uses
 // the remote to send a message that should end up on the same-process receiver.
-TEST_F(MageTest, ChildPassRemoteAndReceiverToParent) {
+TEST_P(MageTest, ChildPassRemoteAndReceiverToParent) {
   launcher->Launch(kChildSendsTwoPipesToParent);
 
   MessagePipe invitation_pipe =
@@ -893,7 +933,7 @@ TEST_F(MageTest, ChildPassRemoteAndReceiverToParent) {
 // `target_endpoint` of the message it receives and forwards, but also has to
 // set each endpoint that it received and processed into the proxying state as
 // well.
-TEST_F(MageTest, ChildPassRemoteAndReceiverToParentToSendEndpointBaringMessageOver) {
+TEST_P(MageTest, ChildPassRemoteAndReceiverToParentToSendEndpointBaringMessageOver) {
   launcher->Launch(kChildSendsTwoPipesToParent);
 
   MessagePipe invitation_pipe =
@@ -1014,7 +1054,7 @@ class HandleAccepterImpl2 : public magen::HandleAccepter, public magen::Callback
 //   the same endpoint over and over again with unique cross-node endpoint name.
 //
 // See the next test for even more complicated logic being exercised.
-TEST_F(MageTest, PassHandleBackAndForthBetweenProcesses) {
+TEST_P(MageTest, PassHandleBackAndForthBetweenProcesses) {
   launcher->Launch(kPassPipeBackAndForth);
 
   MessagePipe invitation_pipe =
@@ -1154,7 +1194,7 @@ class HandleAccepterImpl3 : public magen::HandleAccepter, public magen::Callback
 //   1.) Automatic proxying of user messages that contain endpoints. This is
 //   mostly the logic that exists in `PrepareToForwardUserMessage()`. See the
 //   documentation for why it is complicated.
-TEST_F(MageTest, PassEndpointBearingHandleBackAndForthBetweenProcesses) {
+TEST_P(MageTest, PassEndpointBearingHandleBackAndForthBetweenProcesses) {
   launcher->Launch(kPassPipeBackAndForth);
 
   MessagePipe invitation_pipe =
@@ -1180,7 +1220,7 @@ TEST_F(MageTest, PassEndpointBearingHandleBackAndForthBetweenProcesses) {
 
 
 /////////////////////////////// IN-PROCESS TESTS ///////////////////////////////
-TEST_F(MageTest, InProcessQueuedMessagesAfterReceiverBound) {
+TEST_P(MageTest, InProcessQueuedMessagesAfterReceiverBound) {
   std::vector<MessagePipe> mage_handles = mage::Core::CreateMessagePipes();
   EXPECT_EQ(mage_handles.size(), 2);
 
@@ -1221,7 +1261,7 @@ TEST_F(MageTest, InProcessQueuedMessagesAfterReceiverBound) {
   EXPECT_EQ(impl.received_amount, 5000);
   EXPECT_EQ(impl.received_currency, "USD");
 }
-TEST_F(MageTest, InProcessQueuedMessagesBeforeReceiverBound) {
+TEST_P(MageTest, InProcessQueuedMessagesBeforeReceiverBound) {
   std::vector<MessagePipe> mage_handles = mage::Core::CreateMessagePipes();
   EXPECT_EQ(mage_handles.size(), 2);
 
@@ -1326,7 +1366,7 @@ class FirstInterfaceImpl final : public magen::FirstInterface {
 //  1.) FirstInterface (carry SecondInterface)
 //  2.) FirstInterface
 //  3.) SecondInterface
-TEST_F(MageTest, OrderingNotPreservedBetweenPipes_SendBeforeReceiverBound) {
+TEST_P(MageTest, OrderingNotPreservedBetweenPipes_SendBeforeReceiverBound) {
   std::vector<MessagePipe> first_interface_handles = mage::Core::CreateMessagePipes();
   MessagePipe first_remote_handle = first_interface_handles[0],
              first_receiver_handle = first_interface_handles[1];
@@ -1374,7 +1414,7 @@ TEST_F(MageTest, OrderingNotPreservedBetweenPipes_SendBeforeReceiverBound) {
   EXPECT_TRUE(first_impl.send_string_called);
   EXPECT_TRUE(second_impl.send_string_and_notify_done_called);
 }
-TEST_F(MageTest, OrderingNotPreservedBetweenPipes_SendAfterReceiverBound) {
+TEST_P(MageTest, OrderingNotPreservedBetweenPipes_SendAfterReceiverBound) {
   std::vector<MessagePipe> first_interface_handles = mage::Core::CreateMessagePipes();
   MessagePipe first_remote_handle = first_interface_handles[0],
              first_receiver_handle = first_interface_handles[1];
@@ -1429,7 +1469,7 @@ TEST_F(MageTest, OrderingNotPreservedBetweenPipes_SendAfterReceiverBound) {
 // Another test to show that the ordering between two pipes cannot be relied
 // upon. We demonstrate this by just having two interfaces and binding their
 // receivers in the opposite order from which messages were sent over them.
-TEST_F(MageTest, OrderingNotPreservedBetweenPipes_Simple) {
+TEST_P(MageTest, OrderingNotPreservedBetweenPipes_Simple) {
   std::vector<MessagePipe> first_interface_handles = mage::Core::CreateMessagePipes();
   MessagePipe first_remote_handle = first_interface_handles[0],
              first_receiver_handle = first_interface_handles[1];
@@ -1494,7 +1534,7 @@ class TestInterfaceOnWorkerThread : public magen::TestInterface {
   base::ThreadChecker thread_checker_;
 };
 
-TEST_F(MageTest, InProcessCrossThread) {
+TEST_P(MageTest, InProcessCrossThread) {
   base::Thread worker_thread(base::ThreadType::WORKER);
   worker_thread.Start();
 
@@ -1513,7 +1553,7 @@ TEST_F(MageTest, InProcessCrossThread) {
   worker_thread.GetTaskRunner()->PostTask([&](){
     impl = std::make_unique<TestInterfaceOnWorkerThread>(
         remote_handle,
-        std::bind(&base::TaskLoop::Quit, base::GetUIThreadTaskLoop().get()));
+        std::bind(&base::TaskLoop::Quit, main_thread));
   });
 
   // Run the main loop until we quit as a result of the last message being
@@ -1528,7 +1568,7 @@ TEST_F(MageTest, InProcessCrossThread) {
   EXPECT_TRUE(impl->has_called_send_money);
 }
 
-TEST_F(MageTest, SendMessageToDeletedReceiver) {
+TEST_P(MageTest, SendMessageToDeletedReceiver) {
   std::vector<MessagePipe> mage_handles = mage::Core::CreateMessagePipes();
   EXPECT_EQ(mage_handles.size(), 2);
 
@@ -1576,7 +1616,7 @@ class HandleAccepterImpl : public magen::HandleAccepter {
   mage::Receiver<magen::HandleAccepter> receiver_;
   std::unique_ptr<CallbackInterfaceImpl> callback_impl_;
 };
-TEST_F(MageTest, SendHandleToBoundEndpoint) {
+TEST_P(MageTest, SendHandleToBoundEndpoint) {
   std::vector<MessagePipe> mage_handles = mage::Core::CreateMessagePipes();
   EXPECT_EQ(mage_handles.size(), 2);
 

--- a/mage/core/node.cc
+++ b/mage/core/node.cc
@@ -12,7 +12,6 @@ namespace mage {
 
 std::pair<std::shared_ptr<Endpoint>, std::shared_ptr<Endpoint>>
 Node::InitializeAndEntangleEndpoints() const {
-  CHECK_ON_THREAD(base::ThreadType::UI);
   std::shared_ptr<Endpoint> ep1(
       new Endpoint(/*name=*/util::RandomIdentifier()));
   std::shared_ptr<Endpoint> ep2(
@@ -35,6 +34,7 @@ Node::InitializeAndEntangleEndpoints() const {
 }
 
 void Node::RegisterEndpoint(std::shared_ptr<Endpoint> new_endpoint) {
+  // TODO(domfarolino): Probably local `local_endpoints_` here.
   // Make sure the endpoint isn't already registered.
   auto it = local_endpoints_.find(new_endpoint->name);
   CHECK_EQ(it, local_endpoints_.end());
@@ -43,7 +43,6 @@ void Node::RegisterEndpoint(std::shared_ptr<Endpoint> new_endpoint) {
 }
 
 std::vector<MessagePipe> Node::CreateMessagePipes() {
-  CHECK_ON_THREAD(base::ThreadType::UI);
   std::vector<std::pair<MessagePipe, std::shared_ptr<Endpoint>>>
       pipes_and_endpoints = Node::CreateMessagePipesAndGetEndpoints();
   return {pipes_and_endpoints[0].first, pipes_and_endpoints[1].first};
@@ -51,12 +50,12 @@ std::vector<MessagePipe> Node::CreateMessagePipes() {
 
 std::vector<std::pair<MessagePipe, std::shared_ptr<Endpoint>>>
 Node::CreateMessagePipesAndGetEndpoints() {
-  CHECK_ON_THREAD(base::ThreadType::UI);
   const auto& [endpoint_1, endpoint_2] = InitializeAndEntangleEndpoints();
   MessagePipe handle_1 = Core::Get()->GetNextMessagePipe(),
               handle_2 = Core::Get()->GetNextMessagePipe();
   Core::Get()->RegisterLocalHandleAndEndpoint(handle_1, endpoint_1);
   Core::Get()->RegisterLocalHandleAndEndpoint(handle_2, endpoint_2);
+  // TODO(domfarolino): Probably lock `local_endpoints_` here.
   CHECK_NE(local_endpoints_.find(endpoint_1->name), local_endpoints_.end());
   CHECK_NE(local_endpoints_.find(endpoint_2->name), local_endpoints_.end());
   return {std::make_pair(handle_1, endpoint_1),
@@ -64,7 +63,6 @@ Node::CreateMessagePipesAndGetEndpoints() {
 }
 
 MessagePipe Node::SendInvitationAndGetMessagePipe(int fd) {
-  CHECK_ON_THREAD(base::ThreadType::UI);
   // This node wishes to invite another fresh peer node to the network of
   // processes. The sequence of events here looks like so:
   //   Endpoints:
@@ -108,9 +106,13 @@ MessagePipe Node::SendInvitationAndGetMessagePipe(int fd) {
 
   NodeName temporary_remote_node_name = util::RandomIdentifier();
 
+  // TODO(domfarolino): Probably lock `node_channel_map_` here, since another
+  // thread could be accessing this at the same time when sending a remote
+  // message.
   auto it = node_channel_map_.insert(
       {temporary_remote_node_name,
        std::make_unique<Channel>(fd, /*delegate=*/this)});
+  // TODO(domfarolino): Maybe lock this?
   pending_invitations_.insert({temporary_remote_node_name, remote_endpoint});
 
   // Similar to `AcceptInvitation()` below, only start the channel after it and

--- a/mage/core/node.h
+++ b/mage/core/node.h
@@ -27,11 +27,14 @@ class Node : public Channel::Delegate {
   }
   ~Node() = default;
 
+  // Thread-safe.
   std::vector<MessagePipe> CreateMessagePipes();
+
   MessagePipe SendInvitationAndGetMessagePipe(int fd);
   void AcceptInvitation(int fd);
   void SendMessage(std::shared_ptr<Endpoint> local_endpoint, Message message);
 
+  // Thread-safe.
   void RegisterEndpoint(std::shared_ptr<Endpoint>);
 
   // Channel::Delegate implementation:

--- a/mage/core/node.h
+++ b/mage/core/node.h
@@ -68,6 +68,9 @@ class Node : public Channel::Delegate {
   // All endpoints that are local to this node, that is, whose address's
   // "node name" is our |name_|.
   std::map<EndpointName, std::shared_ptr<Endpoint>> local_endpoints_;
+  // This is used to synchronized access to `local_endpoints_` above, since it
+  // can be accessed from multiple threads.
+  base::Mutex local_endpoints_lock_;
 
   // Used when we send a message from a (necessarily, local) endpoint in order
   // to find the channel associated with its peer endpoint. Without this, we

--- a/mage/core/util.cc
+++ b/mage/core/util.cc
@@ -1,4 +1,5 @@
 #include <string>
+#include <random>
 
 #include "mage/public/message.h"  // For `kIdentifierSize`.
 #include "mage/public/util.h"
@@ -6,14 +7,22 @@
 namespace mage {
 namespace util {
 
+namespace {
+
+thread_local std::mt19937 generator(std::random_device{}());
+
+}; // namespace.
+
 // TODO(domfarolino): Using strings as random identifiers complicates things. In
 // particular, it means the control messages have to manage character buffers
 // intead of something more contained and easily copyable, like random integers.
 // We should consider changing this.
 std::string RandomIdentifier() {
   std::string return_id;
+
+  std::uniform_int_distribution<int> distribution(0, sizeof(alphanum) - 1);
   for (int i = 0; i < kIdentifierSize; ++i) {
-    return_id += alphanum[rand() % (sizeof(alphanum) - 1)];
+    return_id += alphanum[distribution(generator)];
   }
 
   return return_id;

--- a/mage/public/api.h
+++ b/mage/public/api.h
@@ -24,6 +24,7 @@ class ReceiverDelegate;
 void Init(bool verbose = false);
 void Shutdown();
 
+// Thread-safe.
 std::vector<MessagePipe> CreateMessagePipes();
 MessagePipe SendInvitationAndGetMessagePipe(
     int fd,

--- a/mage/test/BUILD
+++ b/mage/test/BUILD
@@ -120,3 +120,15 @@ cc_binary(
   ],
   visibility = ["//visibility:public"],
 )
+cc_binary(
+  name = "child_threads_send_racy_ipcs",
+  srcs = [
+    "child_threads_send_racy_ipcs.cc",
+  ],
+  deps = [
+    "@base//base",
+    "//mage/public",
+    "//mage/test/magen:include",
+  ],
+  visibility = ["//visibility:public"],
+)

--- a/mage/test/child_threads_send_racy_ipcs.cc
+++ b/mage/test/child_threads_send_racy_ipcs.cc
@@ -1,0 +1,86 @@
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "base/check.h"
+#include "base/scheduling/scheduling_handles.h"
+#include "base/scheduling/task_loop_for_io.h"
+#include "base/threading/thread_checker.h"
+#include "mage/public/api.h"
+#include "mage/public/bindings/message_pipe.h"
+#include "mage/public/bindings/remote.h"
+#include "mage/test/magen/callback_interface.magen.h"  // Generated.
+#include "mage/test/magen/handle_accepter.magen.h"  // Generated.
+
+// See the test `MageTest.MultiThreadRacyMessageSendingFromRemoteProcess` that
+// corresponds to this test binary.
+
+const int kNumThreads = 10;
+const int kNumThreads = 100;
+
+class HandleAccepter : public magen::HandleAccepter {
+ public:
+  HandleAccepter(mage::MessagePipe receiver_pipe) {
+    receiver_.Bind(receiver_pipe, this);
+  }
+
+  void PassHandle(mage::MessagePipe remote_pipe) override {
+    remote_pipes_.push_back(remote_pipe);
+
+    if (remote_pipes_.size() == kNumThreads) {
+      std::vector<std::unique_ptr<base::Thread>> worker_threads;
+
+      // Create all of the threads and send all of the messages back to the parent.
+      for (int i = 0; i < kNumThreads; ++i) {
+        mage::MessagePipe remote_pipe = remote_pipes_[i];
+
+        worker_threads.push_back(std::make_unique<base::Thread>(base::ThreadType::WORKER));
+        worker_threads[i]->Start();
+        worker_threads[i]->GetTaskRunner()->PostTask([remote_pipe](){
+          mage::Remote<magen::CallbackInterface> callback_remote;
+          callback_remote.Bind(remote_pipe);
+        
+          // Invoke `NotifyDone()` on the callback (that lives on the main thread)
+          // `kNumMessagesEachThread` times.
+          for (int j = 0; j < kNumMessagesEachThread; ++j) {
+            callback_remote->NotifyDone();
+          }
+        }
+      }
+  }
+
+ private:
+  mage::Receiver<magen::HandleAccepter> receiver_;
+  std::vector<mage::MessagePipe> remote_pipes_;
+};
+
+void OnInvitationAccepted(mage::MessagePipe receiver_handle) {
+  CHECK_ON_THREAD(base::ThreadType::UI);
+  HandleAccepter handle_accepter(receiver_handle);
+
+  // Run indefinitely. This process will do its thing and then quietly hang
+  // until the parent kills it after the test.
+  base::GetCurrentThreadTaskLoop()->Run();
+}
+
+int main(int argc, char** argv) {
+  std::shared_ptr<base::TaskLoop> main_thread =
+      base::TaskLoop::Create(base::ThreadType::UI);
+  base::Thread io_thread(base::ThreadType::IO);
+  io_thread.Start();
+  io_thread.GetTaskRunner()->PostTask(main_thread->QuitClosure());
+  main_thread->Run();
+
+  mage::Init();
+
+  CHECK_EQ(argc, 2);
+  int fd = std::stoi(argv[1]);
+  mage::AcceptInvitation(fd, &OnInvitationAccepted);
+
+  main_thread->Run();
+  return 0;
+}


### PR DESCRIPTION
This PR makes much more of Mage core thread-safe by:
 - Removing some `//base`-specific named-thread assertions
 - Locking more data structures and state within `Core` and `Node`, to allow:
    - Message pipes to be created in a thread-safe way from any thread
    - Messages to *mostly* be sent and received from any thread (probably the entire message sending process needs a full audit after this PR though)
 - Tests:
    - Parameterizing all tests so that the main thread is either a `UI` thread (with a dedicated `IO` thread separately) or just a plain `IO` thread period
    - Adding more thread-safety tests for (a) message pipe creation, and (b) message sending both same-process and cross-process

Makes a lot of progress on #13.