### PR TITLE
Make more of `Node` thread-safe

### DIFF
--- a/mage/core/node.h
+++ b/mage/core/node.h
@@ -29,7 +29,6 @@ class Node : public Channel::Delegate {
 
   // Thread-safe.
   std::vector<MessagePipe> CreateMessagePipes();
-
   MessagePipe SendInvitationAndGetMessagePipe(int fd);
   void AcceptInvitation(int fd);
   void SendMessage(std::shared_ptr<Endpoint> local_endpoint, Message message);

--- a/mage/core/node.h
+++ b/mage/core/node.h
@@ -82,6 +82,7 @@ class Node : public Channel::Delegate {
   // endpoint in the same node (that is, from an endpoint in Node A to its peer
   // endpoint also in Node A) go through a different path.
   std::map<NodeName, std::unique_ptr<Channel>> node_channel_map_;
+  base::Mutex node_channel_map_lock_;
 
   // Maps |NodeNames| that we've sent invitations to and are awaiting
   // acceptances from, to an |Endpoint| that we've reserved for the peer node.
@@ -91,6 +92,7 @@ class Node : public Channel::Delegate {
   // we've given it, we update instances of its temporary name with its "real"
   // one that it provides in the invitation acceptance message.
   std::map<NodeName, std::shared_ptr<Endpoint>> pending_invitations_;
+  base::Mutex pending_invitations_lock_;
 };
 
 };  // namespace mage

--- a/mage/public/api.h
+++ b/mage/public/api.h
@@ -29,6 +29,7 @@ std::vector<MessagePipe> CreateMessagePipes();
 MessagePipe SendInvitationAndGetMessagePipe(
     int fd,
     base::OnceClosure callback = base::OnceClosure());
+// Should only be called once per process (generally right after `Init()`).
 void AcceptInvitation(
     int fd,
     std::function<void(MessagePipe)> finished_accepting_invitation_callback);


### PR DESCRIPTION
This PR makes progress on #13 by making `Node::node_channel_map_` and `Node::pending_invitations_` thread-safe. This is tested by a `CoreUnitTest.MultiThreadRacyInvitationSending` that this PR adds, which tests a bunch of threads sending a bunch of invitations at the same time, and asserting that internal state is consistently maintained.